### PR TITLE
Fix statusBarItem hidden on launch

### DIFF
--- a/QuickCode/AppDelegate.swift
+++ b/QuickCode/AppDelegate.swift
@@ -28,6 +28,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Create the status item
         self.statusBarItem = NSStatusBar.system.statusItem(withLength: CGFloat(NSStatusItem.squareLength))
         statusBarItem.behavior = [.removalAllowed, .terminationOnRemoval]
+        statusBarItem.isVisible = true
 
         if let button = self.statusBarItem.button {
             let itemImage = NSImage(named: "StatusBarIcon")


### PR DESCRIPTION
It seems that `NSStatusItem` has an automatic `autosaveName` that persists whether the item is visible. Setting `isVisible` to `true` on launch fixes the invisibility when the app launches the second time.